### PR TITLE
org-mode integration

### DIFF
--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -955,5 +955,8 @@ buffer is saved before the command is executed."
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.gv\\'" . graphviz-dot-mode))
 
+(eval-after-load 'org-mode
+    (add-to-list 'org-src-lang-modes  '("dot" . graphviz-dot)))
+
 (provide 'graphviz-dot-mode)
 ;;; graphviz-dot-mode.el ends here


### PR DESCRIPTION
With this fix, inline dotfile source in org-mode buffer will be recognized with graphviz-dot-mode.
I think it would be useful for those who write inline dotfile in org-mode like me.
How do you think about it? If you like it, please merge it.

Thanks.