### PR TITLE
Don't color names of colors inside other words

### DIFF
--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -474,7 +474,7 @@ The list of constant is available at http://www.research.att.com/~erg/graphviz\
     ;; convert them to a list of strings, and make
     ;; an optimized regexp from them
     (,(let ((max-specpdl-size (max max-specpdl-size 1200)))
-  (regexp-opt graphviz-dot-color-keywords))
+        (regexp-opt graphviz-dot-color-keywords 'words))
      . font-lock-string-face)
     (,(concat
        (regexp-opt graphviz-dot-attr-keywords 'words)


### PR DESCRIPTION
graphviz-dot-font-lock-keywords: Add word bounderies to color
keywords-regexp.

(Changed branch so I can work with master on my own clone)