### PR TITLE
autoload company-graphviz-dot-backend

### DIFF
--- a/company-graphviz-dot.el
+++ b/company-graphviz-dot.el
@@ -89,8 +89,9 @@ arrow, shape, style, dir, outputmode or other."
            (t 'other)))))))
 
 
+;;;###autoload
 (defun company-graphviz-dot-backend (command &optional arg &rest ignored)
-  "Company back-end for `graphviz-dot-mode'.
+  "Company backend for `graphviz-dot-mode'.
 In the signature, COMMAND, ARG and IGNORED are mandated by `company-mode'."
   (interactive (list 'interactive))
   (cl-case command


### PR DESCRIPTION
This just adds an autoload cookie to the company backend.

Autoloading the backend gives users more freedom to place the backend 
in `company-backends` at their discrection and avoids uneccessary 
`require`s of the library (or other autoload workarounds, etc).