### PR TITLE
Remove split-window-sensibly call

### DIFF
--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -771,8 +771,6 @@ then indent this and each subgraph in it."
         (message command-result)
       (progn
         (sleep-for 0 graphviz-dot-revert-delay)
-        (when (= (length windows) 1)
-          (split-window-sensibly))
         (with-selected-window (selected-window)
           (switch-to-buffer-other-window (find-file-noselect f-name t))
           ;; I get "changed on disk; really edit the buffer?" prompt w/o this


### PR DESCRIPTION
The call to `split-window-sensibly` splits the window even in frames-only-mode. Removing this call seems to work with frames-only-mode enabled or disabled since `switch-to-buffer-other-window` apparently splits the window itself if necessary.

Reference: https://github.com/davidshepherd7/frames-only-mode/issues/31