### PR TITLE
Fix broken links to homepage

### DIFF
--- a/company-graphviz-dot.el
+++ b/company-graphviz-dot.el
@@ -21,7 +21,7 @@
 
 ;; Authors: Bjarte Johansen <bjarte.johansen@gmail.com>
 ;;          Pieter Pareit <pieter.pareit@gmail.com>
-;; Homepage: http://ppareit.github.com/graphviz-dot-mode/
+;; Homepage: https://ppareit.github.io/graphviz-dot-mode/
 ;; Created:
 ;; Last modified:
 ;; Version: 0.0.1

--- a/texinfo/graphviz-dot-mode.html
+++ b/texinfo/graphviz-dot-mode.html
@@ -175,7 +175,7 @@ M. Stallman, et al.  See <a href="https://www.gnu.org/software/texinfo/">https:/
 ;;          Rubens Ramos &lt;rubensr AT users.sourceforge.net&gt;
 ;;          Eric Anderson http://www.ece.cmu.edu/~andersoe/
 ;; Maintainer: Pieter Pareit &lt;pieter.pareit@gmail.com&gt;
-;; Homepage: http://ppareit.github.com/graphviz-dot-mode/
+;; Homepage: https://ppareit.github.io/graphviz-dot-mode/
 ;; Created: 28 Oct 2002
 ;; Last modified: 25 May 2015
 ;; Version: 0.3.10

--- a/texinfo/graphviz-dot-mode.texi
+++ b/texinfo/graphviz-dot-mode.texi
@@ -133,7 +133,7 @@ This manual is based upon the comments and doc strings in the
 ;;          Rubens Ramos <rubensr AT users.sourceforge.net>
 ;;          Eric Anderson http://www.ece.cmu.edu/~andersoe/
 ;; Maintainer: Pieter Pareit <pieter.pareit@@gmail.com>
-;; Homepage: http://ppareit.github.com/graphviz-dot-mode/
+;; Homepage: https://ppareit.github.io/graphviz-dot-mode/
 ;; Created: 28 Oct 2002
 ;; Last modified: 25 May 2015
 ;; Version: 0.3.10


### PR DESCRIPTION
Note that this broken link also exists on the right hand side of the page at https://github.com/ppareit/graphviz-dot-mode.