### PR TITLE
Support remote files in ‘graphviz-dot-preview’.

### DIFF
--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -1,6 +1,6 @@
 ;;; graphviz-dot-mode.el --- Mode for the dot-language used by graphviz (att).
 
-;; Copyright (C) 2002 - 2020 Pieter Pareit <pieter.pareit@gmail.com>
+;; Copyright (C) 2002 - 2020, 2022 Pieter Pareit <pieter.pareit@gmail.com>
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
@@ -596,10 +596,12 @@ be changed with `graphviz-dot-preview-extension'."
     (setq compile-command
           (concat graphviz-dot-dot-program
                   " -T" graphviz-dot-preview-extension " "
-                  (shell-quote-argument f-name)
+                  (shell-quote-argument
+                   (file-name-unquote (file-local-name f-name)))
                   " -o "
                   (shell-quote-argument
-                   (graphviz-output-file-name f-name))))))
+                   (file-name-unquote
+                    (file-local-name (graphviz-output-file-name f-name))))))))
 
 (defvar dot-menu nil
   "Menu for Graphviz Dot Mode.


### PR DESCRIPTION
This requires taking the local name and potentially unquoting it because the
‘dot’ binary wouldn’t know what to do with Emacs remote filenames.