### PR TITLE
Remove obsolete function call

### DIFF
--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -640,7 +640,6 @@ Variables specific to this mode:
   (when (buffer-file-name)
     (setq-local compile-command
                 (graphviz-compile-command (buffer-file-name))))
-  (when dot-menu (easy-menu-add dot-menu))
   (add-to-list 'compilation-error-regexp-alist 'dot)
   (add-to-list 'compilation-error-regexp-alist-alist
 	       '(dot "^Error: \\(.+\\): .*error in line \\([0-9]+\\).*" 1 2))


### PR DESCRIPTION
For several versions, the function `easy-menu-add` has been a no-op
function in Emacs, aliased to `ignore`. In Emacs 28, this function is
now deprecated.

This commit removes `easy-menu-add` from graphviz-dot-mode.el.