### PR TITLE
fix(`graphviz-dot-indent-width`)!: default from `standard-indent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ dot-file viewer command name when you use `C-c C-v`
 the viewer command variable `graphviz-dot-view-command` every time you
 use `C-c C-v` or `nil` to avoid the prompt.
 
-* `graphviz-dot-indent-width` integer, default: `default-tab-width`
+* `graphviz-dot-indent-width` integer, default: `standard-indent`
 
   This variable determines the indentation used in `graphviz-dot-mode`
 buffers.

--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -192,7 +192,7 @@ You can use `%s' in this string, and it will be substituted by the buffer name."
   :type 'boolean
   :group 'graphviz)
 
-(defcustom graphviz-dot-indent-width tab-width
+(defcustom graphviz-dot-indent-width standard-indent
   "*Indentation width in Graphviz Dot mode buffers."
   :type 'integer
   :group 'graphviz)

--- a/texinfo/graphviz-dot-mode.texi
+++ b/texinfo/graphviz-dot-mode.texi
@@ -567,8 +567,8 @@ is called when a semicolon @kbd{;} is typed. Set this boolean variable
 to @code{t} (true) or @code{nil} (false).
 
 @item graphviz-dot-indent-width
-@vindex default-tab-width
-integer, default: @code{default-tab-width}
+@vindex standard-indent
+integer, default: @code{standard-indent}
 
 This variable determines the indentation used in @value{PACKAGE} buffers.
 


### PR DESCRIPTION
What
===

Use `standard-indent` instead of `tab-width` as the default value for `graphviz-dot-indent-width`.

Why
===

The `tab-width` documentation states the following.

> Distance between tab stops (for display of tab characters), in columns.
>
> This controls the width of a TAB character on display.
> The value should be a positive integer.
> Note that this variable doesn't necessarily affect the size of the
> indentation step.  However, if the major mode's indentation facility
> inserts one or more TAB characters, this variable will affect the
> indentation step as well, even if indent-tabs-mode is non-nil.

So when indentation is not done with hard tabs, the `tab-width` should not affect the number of indentations, and therefore I don't think it is correct to treat it as the default value for indentation.

I am not completely confident about what to use then, but I think `standard-indent` is better.

What we are not doing.
===

When I converted texi files to HTML, I did not update the HTML because the tool here is too new or a considerable number of conversions were made.