### PR TITLE
Change make-process coding to binary (fixes #75)

### DIFF
--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -881,6 +881,7 @@ representing the current buffer's point where the graph definition starts
                               ,(format "-T%s" graphviz-dot-preview-extension))
                    :buffer stdout
                    :stderr stderr
+                   :coding 'binary
                    :sentinel
                    (lambda (_ event)
                      (cond


### PR DESCRIPTION
This fixes preview in PNG format. The last byte by dot command didn't end up to Emacs buffer and image was considered as corrupted. 

This fixes #75.