### PR TITLE
Fix docstring and max-specpdl-size warnings

### DIFF
--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -560,7 +560,7 @@ See URL `https://graphviz.org/doc/info/colors.html'")
     ;; after that we take the list of symbols,
     ;; convert them to a list of strings, and make
     ;; an optimized regexp from them
-    (,(let ((max-specpdl-size (max max-specpdl-size 1200)))
+    (,(let ((max-lisp-eval-depth (max max-lisp-eval-depth 1200)))
         (regexp-opt graphviz-dot-color-keywords 'words))
      . font-lock-string-face)
     (,(concat

--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -257,7 +257,7 @@ See URL `https://graphviz.org/docs/attr-types/arrowType/'.")
     "vee" "lvee" "rvee"
     "curve" "lcurve" "rcurve" "ocurve" "olcurve" "orcurve")
   "The possible values that an attribute of type `arrowType' can have.
-See URL 'https://graphviz.org/doc/info/arrows.html.'")
+See URL `https://graphviz.org/doc/info/arrows.html.'")
 
 (defvar graphviz-attributes-type-shape
   '("shape")


### PR DESCRIPTION
Changes:
- Replace single quote with backquote in docstring for `graphviz-values-type-arrow`. I didn't simply escape the quote because I saw the backquote form being used in other URLs.
- Replace obsolete `max-specpdl-size` variable with `max-lisp-eval-depth`, since the former is obsolete since 29.1. According to its documentation:
  > To prevent runaway recursion, use `max-lisp-eval-depth` instead; it will indirectly limit the specpdl stack size as well.

Fixes the following warnings:
```
Warning (comp): graphviz-dot-mode.el:248:2: Warning: defvar `graphviz-values-type-arrow' docstring has wrong usage of unescaped single quotes (use \= or different quoting)
Warning (comp): graphviz-dot-mode.el:563:36: Warning: ‘max-specpdl-size’ is an obsolete variable (as of 29.1).
Warning (comp): graphviz-dot-mode.el:563:14: Warning: ‘max-specpdl-size’ is an obsolete variable (as of 29.1).
```

Sorry if I should have made a different PR for each commit.