### PR TITLE
Add 'no-conversion coding to the preview process.

### DIFF
--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -881,6 +881,7 @@ representing the current buffer's point where the graph definition starts
                               ,(format "-T%s" graphviz-dot-preview-extension))
                    :buffer stdout
                    :stderr stderr
+                   :coding 'no-conversion
                    :sentinel
                    (lambda (_ event)
                      (cond


### PR DESCRIPTION
I was seeing CRC errors from the PNG plugin trying to show the preview of a graph.  Looking at the raw bytes, it seemed that the only difference between the preview buffer and a generated png was that the generated png ended with an extra \202 showing.

So, I took a guess that this was likely an encoding issue, and went with no-conversion to see if that would get things working.