### PR TITLE
Set the connection-type of process graphviz-dot to pipe (Fix issue #75)

### DIFF
--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -881,6 +881,7 @@ representing the current buffer's point where the graph definition starts
                               ,(format "-T%s" graphviz-dot-preview-extension))
                    :buffer stdout
                    :stderr stderr
+                   :connection-type 'pipe
                    :sentinel
                    (lambda (_ event)
                      (cond


### PR DESCRIPTION
make-process default use pty device as IPC device, and pty device has line-buffer behind it, which will buffer the output. The output of subprocess received by parent process my incomplete if the subprocess does not flush the pty device when it exit.