### PR TITLE
Remove unused variable graphviz-dot-revert-delay

### DIFF
--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -117,11 +117,6 @@ file.dot -o file.png'."
   :type 'boolean
   :group 'graphviz)
 
-(defcustom graphviz-dot-revert-delay 300
-  "*Amount of time to sleep before attempting to display the rendered image."
-  :type 'number
-  :group 'graphviz)
-
 (defcustom graphviz-dot-attr-keywords
   '("graph" "digraph" "subgraph" "node" "edge" "strict" "rankdir"
     "size" "page" "Damping" "Epsilon" "URL" "arrowhead" "arrowsize"


### PR DESCRIPTION
The variable is no longer used since 4f7b4d04250c20e6d5d2afa0a09214e9a269fd12.